### PR TITLE
Removes turtle import

### DIFF
--- a/sparseinst/decoder.py
+++ b/sparseinst/decoder.py
@@ -1,7 +1,6 @@
 # Copyright (c) Tianheng Cheng and its affiliates. All Rights Reserved
 
 import math
-from turtle import forward
 import torch
 import torch.nn as nn
 from torch.nn import init


### PR DESCRIPTION
`turtle` is not used in the script and importing it causes a lean docker container to throw the error below. `tkinter` shouldn't be necessary, therefore it would be better if we could just remove the `turtle` import:
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/conda/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/app/train_net.py", line 27, in <module>
    from sparseinst import add_sparse_inst_config, COCOMaskEvaluator
  File "/app/SparseInst/sparseinst/__init__.py", line 1, in <module>
    from .sparseinst import SparseInst
  File "/app/SparseInst/sparseinst/sparseinst.py", line 12, in <module>
    from .decoder import build_sparse_inst_decoder
  File "/app/SparseInst/sparseinst/decoder.py", line 4, in <module>
    from turtle import forward
  File "/opt/conda/lib/python3.7/turtle.py", line 107, in <module>
    import tkinter as TK
  File "/opt/conda/lib/python3.7/tkinter/__init__.py", line 36, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
ImportError: libX11.so.6: cannot open shared object file: No such file or directory
```