### PR TITLE
Add setup_logger

### DIFF
--- a/train_net.py
+++ b/train_net.py
@@ -9,6 +9,7 @@ from torch import optim
 import detectron2.utils.comm as comm
 from detectron2.checkpoint import DetectionCheckpointer
 from detectron2.config import get_cfg
+from detectron2.utils.logger import setup_logger
 from detectron2.data import MetadataCatalog, build_detection_train_loader, DatasetMapper
 from detectron2.engine import AutogradProfiler, DefaultTrainer, default_argument_parser, default_setup, launch
 from detectron2.evaluation import COCOEvaluator, verify_results
@@ -154,6 +155,8 @@ def setup(args):
     cfg.merge_from_list(args.opts)
     cfg.freeze()
     default_setup(cfg, args)
+    # Setup logger for "sparseinst" module
+    setup_logger(output=cfg.OUTPUT_DIR, distributed_rank=comm.get_rank(), name="sparseinst")
     return cfg
 
 


### PR DESCRIPTION
Fix https://github.com/hustvl/SparseInst/issues/61.

The augmentation is not logged during training because the logger `__name__` at this point would be `sparseinst.dataset_mapper` and the `sparseinst` logger was not set up. This PR fixes it the same way a couple of other detectron2-based projects do:
- [DensePose](https://github.com/facebookresearch/detectron2/blob/5aeb252b194b93dc2879b4ac34bc51a31b5aee13/projects/DensePose/train_net.py#L33-L34)
- [PointSup](https://github.com/facebookresearch/detectron2/blob/5aeb252b194b93dc2879b4ac34bc51a31b5aee13/projects/PointSup/train_net.py#L75-L76)

As a result, the following line will be added to the log:

> **[08/07 13:14:26 sparseinst.dataset_mapper]:** [DatasetMapper] Augmentations used in training: [RandomFlip(), ResizeShortestEdge(short_edge_length=[400, 500, 600], sample_style='choice'), RandomCrop(crop_type='relative_range', crop_size=[0.5, 0.5]), ResizeShortestEdge(short_edge_length=(416, 448, 480, 512, 544, 576, 608, 640), max_size=853, sample_style='choice')]